### PR TITLE
output any errors that occurred while attempting to connect to vSphere

### DIFF
--- a/lib/vSphere/action/connect_vsphere.rb
+++ b/lib/vSphere/action/connect_vsphere.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
             env[:vSphere_connection] = RbVmomi::VIM.connect host: config.host, user: config.user, password: config.password, insecure: config.insecure
             @app.call env
           rescue Exception => e
+            puts "An error occurred while connecting to vSphere: " + e.to_s
             raise VagrantPlugins::VSphere::Errors::VSphereError, :message => e.message
           end
         end


### PR DESCRIPTION
This is pretty useful for debugging a failed connection attempt.

I would say this solves issue #9 (at least for me), though the user-friendliness of the error message depends on the exception raised.
