### PR TITLE
sync_folders: fix rsync on windows

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -44,6 +44,10 @@ en:
       Error: %{stderr}
     too_many_private_networks: |-
       There a more private networks configured than can be assigned to the customization spec
+    rsync_not_found: |-
+      Warning! Folder sync disabled because the rsync binary is
+      missing. Make sure rsync is installed and the binary can
+      be found in PATH.
   config:
     host: |-
       Configuration must specify a vSphere host


### PR DESCRIPTION
This patch adds the changes introduced in
https://github.com/mitchellh/vagrant-aws/pull/77 for vagrant-aws, to fix
rsync on Windows. Some minor adjustments were made to adapt the change
to vagrant-vsphere, but the absolute majority of the work was not done
by myself. I just copy-pasted the necessary changes into the middleware.
