### PR TITLE
Vagrant takes "private_key_path" as an array to support multiple private keys

### DIFF
--- a/lib/vSphere/action/sync_folders.rb
+++ b/lib/vSphere/action/sync_folders.rb
@@ -51,11 +51,21 @@ module VagrantPlugins
             env[:machine].communicate.sudo(
               "chown #{ssh_info[:username]} '#{guestpath}'")
 
+            # Prepare private_key path
+            private_key_options = ""
+            if ssh_info[:private_key_path].class == String
+              private_key_options += " -i '" + ssh_info[:private_key_path] + "'"
+            elsif ssh_info[:private_key_path].class == Array
+              ssh_info[:private_key_path].each do |path|
+                private_key_options += " -i '" + path.to_s + "'"
+              end
+            end
+
             # Rsync over to the guest path using the SSH info
             command = [
               "rsync", "--verbose", "--archive", "-z",
               "--exclude", ".vagrant/",
-              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
+              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{private_key_options}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
             


### PR DESCRIPTION
Now latest Vagrant takes "private_key_path" as an array.

config.ssh.private_key_path - You can also specify multiple private keys by setting this to be an array. This is useful, for example, if you use the default private key to bootstrap the machine, but replace it with perhaps a more secure key later.

I made this patch to be compatible with old and new version of Vagrant.
