### PR TITLE
Make vagrant-vsphere work with VMWare infrastructure/clusters

### DIFF
--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -20,13 +20,13 @@ module VagrantPlugins
           pool_candidates = pool_name.split('/')
           pool_candidates.each do |pool_candidate|
             if pool_candidate != ''
-              if maybe_resource_pool.instance_of? RbVmomi::VIM::ResourcePool
-                maybe_resource_pool = maybe_resource_pool.resourcePool.find { |f| f.name == pool_candidate } or 
-                  fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
-              elsif maybe_resource_pool.instance_of? RbVmomi::VIM::Folder
+              if maybe_resource_pool.is_a? RbVmomi::VIM::Folder
                 maybe_resource_pool = maybe_resource_pool.childEntity.find { |f| f.name == pool_candidate } or 
                   fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
-              elsif maybe_resource_pool.instance_of? RbVmomi::VIM::ClusterComputeResource or maybe_resource_pool.instance_of? RbVmomi::VIM::ComputeResource
+              elsif maybe_resource_pool.is_a? RbVmomi::VIM::ResourcePool
+                maybe_resource_pool = maybe_resource_pool.resourcePool.find { |f| f.name == pool_candidate } or 
+                  fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
+              elsif maybe_resource_pool.is_a? RbVmomi::VIM::ClusterComputeResource or maybe_resource_pool.is_a? RbVmomi::VIM::ComputeResource
                 maybe_resource_pool = maybe_resource_pool.resourcePool.resourcePool.find { |f| f.name == pool_candidate } or 
                   fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
               else
@@ -35,7 +35,7 @@ module VagrantPlugins
             end
           end
 
-          resource_pool = maybe_resource_pool.resourcePool if not maybe_resource_pool.instance_of?(RbVmomi::VIM::ResourcePool) and maybe_resource_pool.respond_to?(:resourcePool)
+          resource_pool = maybe_resource_pool.resourcePool if not maybe_resource_pool.is_a?(RbVmomi::VIM::ResourcePool) and maybe_resource_pool.respond_to?(:resourcePool)
           resource_pool
         end
         

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,8 +73,11 @@ RSpec.configure do |config|
     vm_folder.stub(:findByUuid).with(nil).and_return(nil)
 
     host_folder = double('host_folder')
-    host_folder.stub(:is_a?).and_return(RbVmomi::VIM::ResourcePool)
-    host_folder.stub(:instance_of?).and_return(RbVmomi::VIM::ResourcePool)
+    #We interrogate the type in vim_helpers.get_resource_pool, so make sure we act like a ResourcePool since that is easiest to mock
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::ResourcePool).and_return(true)
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::Folder).and_return(false)
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::ClusterComputeResource).and_return(false)
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::ComputeResource).and_return(false)
     host_folder.stub(:resourcePool).and_return(double('pools', :find => {}))
 
     @data_center = double('data_center',


### PR DESCRIPTION
The current vagrant-vsphere barfs on a cluster as a resource pool name. Calling cr.resourcePool.find returned nil and everything blew up.

This make sure to handle the case where the compute resource is a cluster by grabbing the datacenter host folder and conditionally searching based on its type.

This has been tested on a Clustered VMWare infrastructure deployment running vSphere 4.1.0
