### PR TITLE
Restricting rbvmomi dependency to fix problem with nokogiri

### DIFF
--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   
   # force the use of Nokogiri 1.5.10 to prevent conflicts with older versions of zlib
   s.add_dependency 'nokogiri', '1.5.10'
-  s.add_dependency 'rbvmomi'
+  # force the use of rbvmomi 1.6.x to get around this issue: https://github.com/vmware/rbvmomi/pull/32
+  s.add_dependency 'rbvmomi', '~> 1.6.0'
   s.add_dependency 'i18n', '~> 0.6.4'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Since we are pinned to 1.5.10, we can't pull in an rbvmomi newer than 1.6.x because of a problem with the type attribute. Until the vmware folks merge this pull request: https://github.com/vmware/rbvmomi/pull/32, we are essentially broken.
