### PR TITLE
Correctly find the resource pool even if it is a cluster.

### DIFF
--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -13,8 +13,30 @@ module VagrantPlugins
         end
 
         def get_resource_pool(connection, machine)
-          cr = get_datacenter(connection, machine).find_compute_resource(machine.provider_config.compute_resource_name) or fail Errors::VSphereError, :message => I18n.t('errors.missing_compute_resource')
-          cr.resourcePool.find(machine.provider_config.resource_pool_name) or fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
+          dc = get_datacenter(connection, machine)
+          pool_name = machine.provider_config.resource_pool_name
+          maybe_resource_pool = dc.hostFolder
+
+          pool_candidates = pool_name.split('/')
+          pool_candidates.each do |pool_candidate|
+            if pool_candidate != ''
+              if maybe_resource_pool.is_a? RbVmomi::VIM::Folder
+                maybe_resource_pool = maybe_resource_pool.childEntity.find { |f| f.name == pool_candidate } or 
+                  fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
+              elsif maybe_resource_pool.is_a? RbVmomi::VIM::ResourcePool
+                maybe_resource_pool = maybe_resource_pool.resourcePool.find { |f| f.name == pool_candidate } or 
+                  fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
+              elsif maybe_resource_pool.is_a? RbVmomi::VIM::ClusterComputeResource or maybe_resource_pool.is_a? RbVmomi::VIM::ComputeResource
+                maybe_resource_pool = maybe_resource_pool.resourcePool.resourcePool.find { |f| f.name == pool_candidate } or 
+                  fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
+              else
+                fail Errors::VSphereError, :message => I18n.t('errors.missing_resource_pool')
+              end
+            end
+          end
+
+          resource_pool = maybe_resource_pool.resourcePool if not maybe_resource_pool.is_a?(RbVmomi::VIM::ResourcePool) and maybe_resource_pool.respond_to?(:resourcePool)
+          resource_pool
         end
         
         def get_customization_spec_info_by_name(connection, machine)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,9 +72,18 @@ RSpec.configure do |config|
     vm_folder.stub(:findByUuid).with(MISSING_UUID).and_return(nil)
     vm_folder.stub(:findByUuid).with(nil).and_return(nil)
 
+    host_folder = double('host_folder')
+    #We interrogate the type in vim_helpers.get_resource_pool, so make sure we act like a ResourcePool since that is easiest to mock
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::ResourcePool).and_return(true)
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::Folder).and_return(false)
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::ClusterComputeResource).and_return(false)
+    host_folder.stub(:is_a?).with(RbVmomi::VIM::ComputeResource).and_return(false)
+    host_folder.stub(:resourcePool).and_return(double('pools', :find => {}))
+
     @data_center = double('data_center',
                           :vmFolder => vm_folder,
-                          :find_compute_resource => double('compute resource', :resourcePool => double('pools', :find => {})))
+                          :find_compute_resource => double('compute resource', :resourcePool => double('pools', :find => {})),
+                          :hostFolder => host_folder)
 
     @template = double('template_vm',
                        :parent => @data_center,


### PR DESCRIPTION
This is a more robust way to search for the resource pool. We interrogate the type and search a little but differently depending on what type of resource we are. 

This is very similar to how knife-vsphere searches for resource pools. This was tested on a vmware infrastructure deployment using vCenter/vSphere 4.1
