### PR TITLE
Wait till vm ipaddress isn't empty or nil

### DIFF
--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
           vm = get_vm_by_uuid connection, machine
 
           return nil if vm.nil?
-
+          return nil if vm.guest.ipAddress.nil? || vm.guest.ipAddress.empty?
           return {
               :host => vm.guest.ipAddress,
               :port => 22


### PR DESCRIPTION
Fixes https://github.com/nsidc/vagrant-vsphere/issues/47

Without additional check for ip address content get_ssh_info returns empty string. Problem log:

```
[env-manager-olegz] Waiting for SSH to become available...
DEBUG ssh: Checking whether SSH is ready...
 INFO machine: Calling action: get_ssh_info on provider vSphere (420a2048-5bfc-1e99-bf78-007a74ed78ab)
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x007f3820ed2628>
 INFO warden: Calling IN action: #<Vagrant::Action::Builtin::ConfigValidate:0x007f3820ee27f8>
 INFO warden: Calling IN action: #<VagrantPlugins::VSphere::Action::ConnectVSphere:0x007f3820ee27a8>
 INFO warden: Calling IN action: #<VagrantPlugins::VSphere::Action::GetSshInfo:0x007f3820ee2730>
 INFO warden: Calling IN action: #<VagrantPlugins::VSphere::Action::CloseVSphere:0x007f3820ee2708>
 INFO warden: Calling OUT action: #<VagrantPlugins::VSphere::Action::CloseVSphere:0x007f3820ee2708>
 INFO warden: Calling OUT action: #<VagrantPlugins::VSphere::Action::GetSshInfo:0x007f3820ee2730>
 INFO warden: Calling OUT action: #<VagrantPlugins::VSphere::Action::ConnectVSphere:0x007f3820ee27a8>
 INFO warden: Calling OUT action: #<Vagrant::Action::Builtin::ConfigValidate:0x007f3820ee27f8>
DEBUG ssh: Checking key permissions: /home/olegz/.vagrant.d/insecure_private_key
 INFO ssh: Attempting SSH connnection...
 INFO ssh: Attempting to connect to SSH...
 INFO ssh:   - Host: 
 INFO ssh:   - Port: 22
 INFO ssh:   - Username: vagrant
 INFO ssh:   - Key Path: ["/home/olegz/.vagrant.d/insecure_private_key"]
```
