### PR TITLE
Updates clone.rb/get_name() to allow fqdn's as VM name

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -121,7 +121,7 @@ module VagrantPlugins
           return config.name unless config.name.nil?
 
           prefix = "#{machine.name}"
-          prefix.gsub!(/[^-a-z0-9_]/i, "")
+          prefix.gsub!(/[^-a-z0-9_\.]/i, "")
           # milliseconds + random number suffix to allow for simultaneous `vagrant up` of the same box in different dirs
           prefix + "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
         end


### PR DESCRIPTION
Allowing FQDNs as VM name (or at least as prefix of the VM name) eases integration with other tools, for example Check_MK vSphere monitoring: http://mathias-kettner.de/checkmk_vsphere.html.
