### PR TITLE
Changes Gemfile to https:// source on github instead of git://

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ group :development do
 
   if RUBY_VERSION < "2.0.0" then
     puts "Found old ruby #{RUBY_VERSION}, using old vagrant (v1.4.3)"
-    gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.4.3'
+    gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git', :tag => 'v1.4.3'
   else
-    gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git'
+    gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git'
   end
 end


### PR DESCRIPTION
Tried to run unit tests, got an error when running bundle install.

This pull request fixes that issue by changing the Gemfile to point to https.

fatal: unable to connect to github.com:
github.com[0: 192.30.252.129]: errno=Connection refused

I can clone other repositories using git:// notation from the same server & I can ssh manually to github.com so I don't know what's going on. If this is indeed some configuration issue on my side please close this pull request.
