### PR TITLE
Fixed missing resource pool in linked clone from a template

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -107,16 +107,15 @@ module VagrantPlugins
               template.ReconfigVM_Task(:spec => spec).wait_for_completion
             end
 
-            RbVmomi::VIM.VirtualMachineRelocateSpec(:diskMoveType => :moveChildMostDiskBacking)
+            location = RbVmomi::VIM.VirtualMachineRelocateSpec(:diskMoveType => :moveChildMostDiskBacking)
           else
             location = RbVmomi::VIM.VirtualMachineRelocateSpec
-            location[:pool] = get_resource_pool(connection, machine) unless config.clone_from_vm
 
             datastore = get_datastore connection, machine
             location[:datastore] = datastore unless datastore.nil?
-
-            location
           end
+          location[:pool] = get_resource_pool(connection, machine) unless config.clone_from_vm
+          location
         end
 
         def get_name(machine, config)


### PR DESCRIPTION
At the moment `linked_clone` option works only from cloning from a virtual machine. Cloning from a template fails with the error:

```
InvalidArgument: A specified parameter was not correct.
spec.location.pool
No error message
```

This pull request fixes this issue by populating CloneSpec with resource pool value in both linked and not linked cloning cases.
Probably the same logic should be applied to datastore value, but I have no such environment to test, so leave this untouched.
