### PR TITLE
#62 - Use root resource pool when cloning from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This provider has the following settings, all are required unless noted:
 * `password` - password  for connecting to vSphere
 * `data_center_name` - _Optional_ datacenter containing the computed resource, the template and where the new VM will be created, if not specified the first datacenter found will be used
 * `compute_resource_name` - _Required if cloning from template_ the name of the host containing the resource pool for the new VM
-* `resource_pool_name` - _Required if cloning from template_ the resource pool for the new VM
+* `resource_pool_name` - the resource pool for the new VM. If not supplied, and cloning from a template, uses the root resource pool
 * `clone_from_vm` - _Optional_ use a virtual machine instead of a template as the source for the cloning operation
 * `template_name` - the VM or VM template to clone
 * `name` - _Optional_ name of the new VM, if missing the name will be auto generated

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -28,9 +28,8 @@ module VagrantPlugins
         errors <<  I18n.t('vsphere.config.password') if password.nil?
         errors <<  I18n.t('vsphere.config.template') if template_name.nil?
 
-        # These are only required if we're cloning from an actual template
+        # Only required if we're cloning from an actual template
         errors << I18n.t('vsphere.config.compute_resource') if compute_resource_name.nil? and not clone_from_vm
-        errors << I18n.t('vsphere.config.resource_pool') if resource_pool_name.nil? and not clone_from_vm
 
         { 'vSphere Provider' => errors }
       end

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -14,7 +14,11 @@ module VagrantPlugins
 
         def get_resource_pool(connection, machine)
           cr = get_datacenter(connection, machine).find_compute_resource(machine.provider_config.compute_resource_name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_compute_resource')
-          cr.resourcePool.find(machine.provider_config.resource_pool_name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_resource_pool')
+          rp = cr.resourcePool
+          if !(machine.provider_config.resource_pool_name.nil?)
+            rp = cr.resourcePool.find(machine.provider_config.resource_pool_name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_resource_pool')
+          end
+          rp
         end
 
         def get_customization_spec_info_by_name(connection, machine)

--- a/spec/clone_spec.rb
+++ b/spec/clone_spec.rb
@@ -6,11 +6,11 @@ describe VagrantPlugins::VSphere::Action::Clone do
   end
 
   it 'should create a CloneVM task' do
-    call    
+    call
     @template.should have_received(:CloneVM_Task).with({
       :folder => @data_center,
       :name => NAME,
-      :spec => {}
+      :spec => {:location => {:pool => @child_resource_pool} }
     })
   end
 
@@ -23,10 +23,20 @@ describe VagrantPlugins::VSphere::Action::Clone do
     call
     @app.should have_received :call
   end
-  
+
   it 'should set static IP when given config spec' do
     @machine.provider_config.stub(:customization_spec_name).and_return('spec')
     call
     @ip.should have_received(:ipAddress=).with('0.0.0.0')
+  end
+
+  it 'should use root resource pool when cloning from template and no resource pool specified' do
+    @machine.provider_config.stub(:resource_pool_name).and_return(nil)
+    call
+    @template.should have_received(:CloneVM_Task).with({
+      :folder => @data_center,
+      :name => NAME,
+      :spec => {:location => {:pool => @root_resource_pool } }
+    })
   end
 end


### PR DESCRIPTION
Fixes #62.

Removes manditory requirement for resource_pool_name when cloning.
Now uses root resource pool if no resource_pool_name supplied.

Apologies if my ruby/rspec is a little odd - I'm pretty new to ruby, but hopefully its okay. Please let me know if there are any improvements I could make.
