### PR TITLE
Incorrect configuration values cause "No error message" output

### DIFF
--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
     module Util
       module VimHelpers
         def get_datacenter(connection, machine)
-          connection.serviceInstance.find_datacenter(machine.provider_config.data_center_name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_datacenter')
+          connection.serviceInstance.find_datacenter(machine.provider_config.data_center_name) or fail Errors::VSphereError, :missing_datacenter
         end
 
         def get_vm_by_uuid(connection, machine)
@@ -13,23 +13,23 @@ module VagrantPlugins
         end
 
         def get_resource_pool(connection, machine)
-          cr = get_datacenter(connection, machine).find_compute_resource(machine.provider_config.compute_resource_name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_compute_resource')
-          cr.resourcePool.find(machine.provider_config.resource_pool_name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_resource_pool')
+          cr = get_datacenter(connection, machine).find_compute_resource(machine.provider_config.compute_resource_name) or fail Errors::VSphereError, :missing_compute_resource
+          cr.resourcePool.find(machine.provider_config.resource_pool_name) or fail Errors::VSphereError, :missing_resource_pool
         end
 
         def get_customization_spec_info_by_name(connection, machine)
           name = machine.provider_config.customization_spec_name
           return if name.nil? || name.empty?
 
-          manager = connection.serviceContent.customizationSpecManager or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.null_configuration_spec_manager') if manager.nil?
-          spec = manager.GetCustomizationSpec(:name => name) or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_configuration_spec') if spec.nil?
+          manager = connection.serviceContent.customizationSpecManager or fail Errors::VSphereError, :null_configuration_spec_manager if manager.nil?
+          spec = manager.GetCustomizationSpec(:name => name) or fail Errors::VSphereError, :missing_configuration_spec if spec.nil?
         end
 
         def get_datastore(connection, machine)
           name = machine.provider_config.data_store_name
           return if name.nil? || name.empty?
 
-          get_datacenter(connection, machine).find_datastore name or fail Errors::VSphereError, :message => I18n.t('vsphere.errors.missing_datastore')
+          get_datacenter(connection, machine).find_datastore name or fail Errors::VSphereError, :missing_datastore
         end
       end
     end


### PR DESCRIPTION
If configuration contains any mistakes, for example datacenter or resource pool name is misspelled, then Vagrant fails with `No error message` output. Actual error message is not displayed.

I changed localization syntax the same way as in https://github.com/nsidc/vagrant-vsphere/pull/58, and it fixed the issue.
