### PR TITLE
Instruct vagrant to set the guest hostname according to Vagrantfile

### DIFF
--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -105,6 +105,7 @@ module VagrantPlugins
           b.use CloseVSphere 
           b.use Provision          
           b.use SyncFolders          
+          b.use SetHostname
         end
       end
 


### PR DESCRIPTION
We are using puppets node keyword to classify each host for provisioning, so require the hostname to get the correct setup.

Thanks.
