### PR TITLE
fixed synced folders to work with WinRM communicator

### DIFF
--- a/lib/vSphere/action/sync_folders.rb
+++ b/lib/vSphere/action/sync_folders.rb
@@ -47,8 +47,13 @@ module VagrantPlugins
                                 :guestpath => guestpath))
 
             # Create the guest path
-            env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
-            env[:machine].communicate.sudo("chown #{ssh_info[:username]} '#{guestpath}'")
+             if env[:machine].communicate.class.to_s =~ /WinRM/
+              env[:machine].communicate.execute("New-Item '#{guestpath}' -type directory -force")
+
+            else 
+              env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
+              env[:machine].communicate.sudo("chown #{ssh_info[:username]} '#{guestpath}'")
+            end
 
             # Rsync over to the guest path using the SSH info
             command = [


### PR DESCRIPTION
synced folders don't work with WinRM communicator because MkDir -p is not a valid powershell command.  Im sure there are more elegant solutions, but this seems to work....
