### PR TITLE
Fixed "No error message" on rbvmomi method calls.

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -39,8 +39,7 @@ module VagrantPlugins
           rescue Errors::VSphereError => e
             raise
           rescue Exception => e
-            puts e.message
-            raise Errors::VSphereError, :message => e.message
+            raise Errors::VSphereError.new, e.message
           end
 
           #TODO: handle interrupted status in the environment, should the vm be destroyed?

--- a/lib/vSphere/action/close_vsphere.rb
+++ b/lib/vSphere/action/close_vsphere.rb
@@ -15,9 +15,7 @@ module VagrantPlugins
           rescue Errors::VSphereError => e
             raise
           rescue Exception => e
-            puts e
-            #raise a properly namespaced error for Vagrant
-            raise Errors::VSphereError, :message => e.message
+            raise Errors::VSphereError.new, e.message
           end
         end
       end

--- a/lib/vSphere/action/connect_vsphere.rb
+++ b/lib/vSphere/action/connect_vsphere.rb
@@ -17,11 +17,10 @@ module VagrantPlugins
               insecure: config.insecure, proxyHost: config.proxy_host,
               proxyPort: config.proxy_port
             @app.call env
-          rescue VSphere::Errors::VSphereError => e
+          rescue Errors::VSphereError => e
             raise
           rescue Exception => e
-            puts e.backtrace
-            raise VagrantPlugins::VSphere::Errors::VSphereError, :message => e.message
+            raise Errors::VSphereError.new, e.message
           end
         end
       end

--- a/lib/vSphere/action/destroy.rb
+++ b/lib/vSphere/action/destroy.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
           rescue Errors::VSphereError => e
             raise
           rescue Exception => e
-            raise Errors::VSphereError, :message => e.message
+            raise Errors::VSphereError.new, e.message
           end
         end
       end


### PR DESCRIPTION
When rbvmomi calls fail with exceptions, custom error messages were passed incorrectly, so _No error message_ is displayed to a user.

This pull request fixed the issue, and displays a correct error message for opening and closing vSphere connections, vm cloning and destroy.
