### PR TITLE
Create the VM target folder if it doesn't exist

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -131,7 +131,7 @@ module VagrantPlugins
           if config.vm_base_path.nil?
             template.parent
           else
-            dc.vmFolder.traverse(config.vm_base_path, RbVmomi::VIM::Folder)
+            dc.vmFolder.traverse(config.vm_base_path, RbVmomi::VIM::Folder, create=true)
           end
         end
       end


### PR DESCRIPTION
Tweaks mikola-spb's change from https://github.com/nsidc/vagrant-vsphere/pull/73 to create the folder if it doesn't exist. This is useful to automatically create these based on Vagrant project name for example.
