### PR TITLE
Use a directory name where Vagrantfile is stored as a prefix for VM name

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
           machine = env[:machine]
           config = machine.provider_config
           connection = env[:vSphere_connection]
-          name = get_name machine, config, env[:root_path].basename.to_s
+          name = get_name machine, config, env[:root_path]
           dc = get_datacenter connection, machine
           template = dc.find_vm config.template_name
           raise Errors::VSphereError, :'missing_template' if template.nil?
@@ -121,7 +121,7 @@ module VagrantPlugins
         def get_name(machine, config, root_path)
           return config.name unless config.name.nil?
 
-          prefix = "#{root_path}_#{machine.name}"
+          prefix = "#{root_path.basename.to_s}_#{machine.name}"
           prefix.gsub!(/[^-a-z0-9_\.]/i, "")
           # milliseconds + random number suffix to allow for simultaneous `vagrant up` of the same box in different dirs
           prefix + "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"


### PR DESCRIPTION
At the moment all virtual machines created on vSphere get names with `default_` prefix. That gets hard to navigate and manage them, when many machines are running in parallel.
A [workaround](http://stackoverflow.com/a/20431791/576361) exists to rename machines from `default` to other values, but it requires additional modifications in each Vagrantfile individually, and doesn't allow to set a default prefix for all instances of the box.

When Vagrant creates VMs under VirtualBox, it uses the current directory name where `Vagranfile` is stored as a prefix.
This PR adds the same logic here.
