### PR TITLE
Lower-case provider name (vSphere=>vsphere)

### DIFF
--- a/example_box/metadata.json
+++ b/example_box/metadata.json
@@ -1,3 +1,3 @@
 {
-  "provider": "vSphere"
+  "provider": "vsphere"
 }


### PR DESCRIPTION
As discussed in https://github.com/nsidc/vagrant-vsphere/pull/86, when a box is not installed locally, and Vagrant downloads it from remote server, it checks the provider name.
If metadata.json within a box file contains incorrect value, it causes errors like

```
(manage-vsphere=)$ vagrant up dev --provider vsphere
Bringing machine 'dev' up with 'vsphere' provider...
==> dev: Running triggers before up...
==> dev: Box 'vsphere' could not be found. Attempting to find and install...
    dev: Box Provider: vsphere
    dev: Box Version: >= 0
==> dev: Adding box 'vsphere' (v0) for provider: vsphere
    dev: Downloading: file:///Users/savoie/Dropbox/projects/vagrant-nsidc/vsphere/vsphere.box
The box you attempted to add doesn't match the provider you specified.

Provider expected: vsphere
Provider of box: vSphere
```

The check is case-sensitive, so the value in metadata must be equal to the name declared by a pugin at https://github.com/nsidc/vagrant-vsphere/blob/master/lib/vSphere/plugin.rb#L16
