### PR TITLE
Nokogiri Major Version Dependency

### DIFF
--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = 'Enables Vagrant to manage machines with VMWare vSphere.'
 
   # force the use of Nokogiri 1.5.x to prevent conflicts with older versions of zlib
-  s.add_dependency 'nokogiri', '>=1.5'
+  s.add_dependency 'nokogiri', '~>1.5'
   # force the use of rbvmomi 1.6.x to get around this issue: https://github.com/vmware/rbvmomi/pull/32
   s.add_dependency 'rbvmomi', '~> 1.6.0'
   s.add_dependency 'i18n', '~> 0.6.4'


### PR DESCRIPTION
Changes to allow the installation of the plugin with the latest version of Vagrant which is bundled with Nokogiri 1.6.x. The dependency would allow all minor versions of Nokogiri after 1.5 to used. 
