### PR TITLE
Add vlan configuration

### DIFF
--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
       attr_accessor :linked_clone
       attr_accessor :proxy_host
       attr_accessor :proxy_port
+      attr_accessor :vlan
 
       def validate(machine)
         errors = _detected_errors

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -35,6 +35,10 @@ module VagrantPlugins
 
           get_datacenter(connection, machine).find_datastore name or fail Errors::VSphereError, :missing_datastore
         end
+
+        def get_network_by_name(dc, name)
+          dc.network.find { |f| f.name == name } or fail Errors::VSphereError, :missing_vlan
+        end
       end
     end
   end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,6 +40,10 @@ en:
         Configured data store not found
       too_many_private_networks: |-
         There a more private networks configured than can be assigned to the customization spec
+      missing_vlan: |-
+        Configured vlan not found
+      missing_network_card: |-
+        Cannot find network card to customize
     config:
       host: |-
         Configuration must specify a vSphere host

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,8 @@ RSpec.configure do |config|
         :clone_from_vm => nil,
         :linked_clone => nil,
         :proxy_host => nil,
-        :proxy_port => nil)
+        :proxy_port => nil,
+        :vlan => nil)
     vm_config = double(
       :vm => double('config_vm',
                     :box => nil,
@@ -101,11 +102,20 @@ RSpec.configure do |config|
                           :pretty_path => "data_center/#{vm_folder}",
                           :find_compute_resource => double('compute resource', :resourcePool => @root_resource_pool))
 
+    @device = RbVmomi::VIM::VirtualEthernetCard.new
+    @device.stub(:backing).and_return(RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo.new)
+
+    @virtual_hardware = double('virtual_hardware',
+                               :device => [@device])
+    @template_config = double('template_config',
+                              :hardware => @virtual_hardware)
+
     @template = double('template_vm',
                        :parent => @data_center,
                        :pretty_path => "#{@data_center.pretty_path}/template_vm",
                        :CloneVM_Task => double('result',
-                                               :wait_for_completion => double('new_vm', :config => double('config', :uuid => NEW_UUID))))
+                                               :wait_for_completion => double('new_vm', :config => double('config', :uuid => NEW_UUID))),
+                       :config => @template_config)
 
     @data_center.stub(:find_vm).with(TEMPLATE).and_return(@template)
 


### PR DESCRIPTION
This is very similar to the -cvlan capability that knife-vsphere gives you.

== DETAILS

-Added a new configuration option 'vlan' that lets you specify the vlan string
-If vlan is set, the clone spec is modified with an edit action to connect the first NIC on the VM to the configured VLAN.

== TESTING

-A new test was added to clone_spec.rb (although specs for API bindings like this mostly just test that you have wired your mocks up correctly). 

-This was tested against vSphere 5.5 both with and without selecting a new VLAN. 
