### PR TITLE
Add the ability to configure the number of CPUs that will be used by the new VM

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
             spec[:customization] = get_customization_spec(machine, customization_info) unless customization_info.nil?
             add_custom_vlan(template, dc, spec, config.vlan) unless config.vlan.nil?
             add_custom_memory(spec, config.memory_mb) unless config.memory_mb.nil?
+            add_custom_cpu(spec, config.cpu_count) unless config.cpu_count.nil?
 
             env[:ui].info I18n.t('vsphere.creating_cloned_vm')
             env[:ui].info " -- #{config.clone_from_vm ? "Source" : "Template"} VM: #{template.pretty_path}"
@@ -156,6 +157,10 @@ module VagrantPlugins
 
         def add_custom_memory(spec, memory_mb)
           spec[:config][:memoryMB] = Integer(memory_mb)
+        end
+
+        def add_custom_cpu(spec, cpu_count)
+          spec[:config][:numCPUs] = Integer(cpu_count)
         end
       end
     end

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
       attr_accessor :proxy_port
       attr_accessor :vlan
       attr_accessor :memory_mb
+      attr_accessor :cpu_count
 
       def validate(machine)
         errors = _detected_errors

--- a/spec/clone_spec.rb
+++ b/spec/clone_spec.rb
@@ -73,6 +73,18 @@ describe VagrantPlugins::VSphere::Action::Clone do
     })
   end
 
+
+  it 'should create a CloneVM spec with configured number of cpus' do
+    @machine.provider_config.stub(:cpu_count).and_return(4)
+    call
+    expect(@template).to have_received(:CloneVM_Task).with({
+      :folder => @data_center,
+      :name => NAME,
+      :spec => {:location => {:pool => @child_resource_pool}, 
+        :config => RbVmomi::VIM.VirtualMachineConfigSpec(:numCPUs => 4) },
+    })
+  end
+
   it 'should set static IP when given config spec' do
     @machine.provider_config.stub(:customization_spec_name).and_return('spec')
     call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,8 @@ RSpec.configure do |config|
         :proxy_host => nil,
         :proxy_port => nil,
         :vlan => nil,
-        :memory_mb => nil)
+        :memory_mb => nil,
+        :cpu_count => nil)
     vm_config = double(
       :vm => double('config_vm',
                     :box => nil,


### PR DESCRIPTION
Add the ability to configure the number of CPUs that will be used by the new VM

== DETAILS
- Added a new configuration option "cpu_count"
- Modified clone.rb to change the number of cpu's on the clone spec to be equal to cpu_count, if specified.

== TESTING
- New spec
- Tested with vSphere 5.5
