### PR TITLE
Alternate method to find compute resource to include cluster computer resources

### DIFF
--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -13,12 +13,54 @@ module VagrantPlugins
         end
 
         def get_resource_pool(connection, machine)
-          cr = get_datacenter(connection, machine).find_compute_resource(machine.provider_config.compute_resource_name) or fail Errors::VSphereError, :missing_compute_resource
+          cr = get_compute_resource(connection, machine)
           rp = cr.resourcePool
           if !(machine.provider_config.resource_pool_name.nil?)
             rp = cr.resourcePool.find(machine.provider_config.resource_pool_name) or  fail Errors::VSphereError, :missing_resource_pool
           end
           rp
+        end
+
+        def get_compute_resource(connection, machine)
+          datacenter = get_datacenter(connection, machine);
+          cr = find_clustercompute_or_compute_resource(datacenter, machine.provider_config.compute_resource_name) or fail Errors::VSphereError, :missing_compute_resource
+          cr
+        end
+
+        def find_clustercompute_or_compute_resource(datacenter, path)
+          if path.is_a? String
+            es = path.split('/').reject(&:empty?)
+          elsif path.is_a? Enumerable
+            es = path
+          else
+            fail "unexpected path class #{path.class}"
+          end
+          return datacenter.hostFolder if es.empty?
+          final = es.pop
+          
+          p = es.inject(datacenter.hostFolder) do |f,e|
+            f.find(e, RbVmomi::VIM::Folder) || return
+          end
+
+          begin
+            if x = p.find(final, RbVmomi::VIM::ComputeResource)
+              x
+            elsif x = p.find(final, RbVmomi::VIM::ClusterComputeResource)
+              x
+            else
+              nil
+            end
+          rescue Exception => e
+# When looking for the ClusterComputeResource there seems to be some parser error in RbVmomi Folder.find, try this instead
+            x = p.childEntity.find { |x| x.name == final }
+            if x.is_a? RbVmomi::VIM::ClusterComputeResource or x.is_a? RbVmomi::VIM::ComputeResource
+              x
+            else
+              puts "ex unknonw type " + x.to_json
+              nil
+            end
+          end
+
         end
 
         def get_customization_spec_info_by_name(connection, machine)


### PR DESCRIPTION
find_compute_resource only finds VIM::ComputeResource
unrolled find_compute_resource to allow for ComputeResource or ClusterComputeResource
RbVmomi parser error with ClusterComputeResource, workaround handling exception and using alternate method to find childEntity in the folder.
