### PR TITLE
Shutdown guest on halt

### DIFF
--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -11,10 +11,14 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
           b.use ConnectVSphere
+
           b.use Call, IsRunning do |env, b2|
             if [:result]
-                b2.use action_halt
-                next
+              b2.use Call, GracefulHalt, :poweroff, :running do |env, b3|
+                if !env[:result]
+                  b3.use PowerOff
+                end
+              end
             end
           end
           b.use Destroy


### PR DESCRIPTION
Proposed fix for #103.  Live tested on vSphere 5.5; 'vagrant halt' now does a 'shutdown' via SSH, 'vagrant destroy' now does a shutdown followed by a vm delete; and 'vagrant halt --force' performs an immediate PowerOff.
