### PR TITLE
Vagrant 1.7 doesn't read vSphere connection info from a base vagrant box

### DIFF
--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -136,6 +136,7 @@ module VagrantPlugins
       #vSphere specific actions
       def self.action_get_state
         Vagrant::Action::Builder.new.tap do |b|
+          b.use HandleBox
           b.use ConfigValidate
           b.use ConnectVSphere
           b.use GetState


### PR DESCRIPTION
This PR fixes a Vagrant 1.7 compatibility issue.

Vagrant fails to start a machine when a vagrant box is downloaded from remote server, and local Vagrantfile doesn't contain vSphere connection info.

```
Error occurred: There are errors in the configuration of this machine. Please fix
the following errors and try again:

vSphere Provider:
* Configuration must specify a vSphere host
* Configuration must specify a vSphere user
* Configuration must specify a vSphere password
* Configuration must specify a template name
* Configuration must specify a compute resource name
```

The values are specified within a base vagrant box, but due to https://github.com/mitchellh/vagrant/issues/4513 `get_state` action is now called earlier.
