### PR TITLE
'vagrant up' fails with 'undefined local variable or method datastore' error

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
           begin
             # Storage DRS does not support vSphere linked clones. http://www.vmware.com/files/pdf/techpaper/vsphere-storage-drs-interoperability.pdf
             ds = get_datastore dc, machine
-            fail Errors::VSphereError, :'invalid_configuration_linked_clone_with_sdrs' if config.linked_clone && datastore.is_a?(RbVmomi::VIM::StoragePod)
+            fail Errors::VSphereError, :'invalid_configuration_linked_clone_with_sdrs' if config.linked_clone && ds.is_a?(RbVmomi::VIM::StoragePod)
 
             location = get_location ds, dc, machine, template
             spec = RbVmomi::VIM.VirtualMachineCloneSpec location: location, powerOn: true, template: false


### PR DESCRIPTION
https://github.com/nsidc/vagrant-vsphere/pull/101 contained a typo, so now vagrant fails to start an instance:
```
>vagrant up --provider=vsphere
Bringing machine 'default' up with 'vsphere' provider...
undefined local variable or method `datastore' for #<VagrantPlugins::VSphere::Action::Clone:0x4e7d2b0>
```