### PR TITLE
'vagrant destroy' fails with 'missing required parameter uuid' error

### DIFF
--- a/lib/vSphere/action/destroy.rb
+++ b/lib/vSphere/action/destroy.rb
@@ -22,6 +22,7 @@ module VagrantPlugins
         private
 
         def destroy_vm(env)
+          return if env[:machine].state.id == :not_created
           vm = get_vm_by_uuid env[:vSphere_connection], env[:machine]
           return if vm.nil?
 


### PR DESCRIPTION
When:
- vsphere is a default vagrant provider
- guest machine is not created yet
- `vagrant destroy` is called

Then vagrant fails with `missing required parameter uuid` error message.

This PR helps handling this situation with no errors, so it doesn't break build scripts.