### PR TITLE
Explicit parallelization support

### DIFF
--- a/lib/vSphere/plugin.rb
+++ b/lib/vSphere/plugin.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:vsphere) do
+      provider(:vsphere, parallel: true) do
         # TODO: add logging
         setup_i18n
 


### PR DESCRIPTION
This declares the provider as capable of using parallelization by default. Without this, VMs are created sequentially and it can take a long time, for instance when extensively deploying from templates (see #32). In this case this is a huge time saver.

It can still be disabled with the `--no-parallel` option.