### PR TITLE
Added `public_address` provider capability

### DIFF
--- a/lib/vSphere/cap/public_address.rb
+++ b/lib/vSphere/cap/public_address.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
           return nil if machine.state.id != :running
 
           ssh_info = machine.ssh_info
-          return nil if !ssh_info
+          return nil unless ssh_info
           ssh_info[:host]
         end
       end

--- a/lib/vSphere/cap/public_address.rb
+++ b/lib/vSphere/cap/public_address.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module VSphere
+    module Cap
+      module PublicAddress
+        def self.public_address(machine)
+          return nil if machine.state.id != :running
+
+          ssh_info = machine.ssh_info
+          return nil if !ssh_info
+          ssh_info[:host]
+        end
+      end
+    end
+  end
+end

--- a/lib/vSphere/plugin.rb
+++ b/lib/vSphere/plugin.rb
@@ -30,6 +30,11 @@ module VagrantPlugins
         Provider
       end
 
+      provider_capability("vsphere", "public_address") do
+        require_relative "cap/public_address"
+        Cap::PublicAddress
+      end
+
       def self.setup_i18n
         I18n.load_path << File.expand_path('locales/en.yml', VSphere.source_root)
         I18n.reload!

--- a/lib/vSphere/plugin.rb
+++ b/lib/vSphere/plugin.rb
@@ -30,8 +30,8 @@ module VagrantPlugins
         Provider
       end
 
-      provider_capability("vsphere", "public_address") do
-        require_relative "cap/public_address"
+      provider_capability('vsphere', 'public_address') do
+        require_relative 'cap/public_address'
         Cap::PublicAddress
       end
 


### PR DESCRIPTION
This PR changes nothing in current plugin logic, but adds a new method to access IP address of running VM from other plugins, for example https://github.com/mkuzmin/vagrant-guestip/blob/master/lib/command.rb#L10

The code is copied from Vagrant core: https://github.com/mitchellh/vagrant/blob/master/plugins/providers/hyperv/cap/public_address.rb