### PR TITLE
Allow full ResourcePool path

### DIFF
--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -13,23 +13,23 @@ module VagrantPlugins
         end
 
         def get_resource_pool(datacenter, machine)
-          baseEntity = get_compute_resource(datacenter, machine)
-          entityArray = machine.provider_config.resource_pool_name.split('/')
-          entityArray.each do |entityArrItem|
-            if entityArrItem != ''
-              if baseEntity.is_a? RbVmomi::VIM::Folder
-                baseEntity = baseEntity.childEntity.find { |f| f.name == entityArrItem } or fail Errors::VSphereError, :missing_resource_pool
-              elsif baseEntity.is_a? RbVmomi::VIM::ClusterComputeResource
-                 baseEntity = baseEntity.resourcePool.resourcePool.find { |f| f.name == entityArrItem } or fail Errors::VSphereError, :missing_resource_pool
-              elsif baseEntity.is_a? RbVmomi::VIM::ResourcePool
-                 baseEntity = baseEntity.resourcePool.find { |f| f.name == entityArrItem } or fail Errors::VSphereError, :missing_resource_pool
+          rp = get_compute_resource(datacenter, machine)
+          entity_array = machine.provider_config.resource_pool_name.split('/')
+          entity_array.each do |entity_array_item|
+            if entity_array_item != ''
+              if rp.is_a? RbVmomi::VIM::Folder
+                rp = rp.childEntity.find { |f| f.name == entity_array_item } or fail Errors::VSphereError, :missing_resource_pool
+              elsif rp.is_a? RbVmomi::VIM::ClusterComputeResource
+                rp = rp.resourcePool.resourcePool.find { |f| f.name == entity_array_item } or fail Errors::VSphereError, :missing_resource_pool
+              elsif rp.is_a? RbVmomi::VIM::ResourcePool
+                rp = rp.resourcePool.find { |f| f.name == entity_array_item } or fail Errors::VSphereError, :missing_resource_pool
               else
                 fail Errors::VSphereError, :missing_resource_pool
               end
             end
           end
-          baseEntity = baseEntity.resourcePool if not baseEntity.is_a?(RbVmomi::VIM::ResourcePool) and baseEntity.respond_to?(:resourcePool)
-          baseEntity
+          rp = rp.resourcePool if not rp.is_a?(RbVmomi::VIM::ResourcePool) and rp.respond_to?(:resourcePool)
+          rp
         end
 
         def get_compute_resource(datacenter, machine)

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -18,17 +18,17 @@ module VagrantPlugins
           entity_array.each do |entity_array_item|
             if entity_array_item != ''
               if rp.is_a? RbVmomi::VIM::Folder
-                rp = rp.childEntity.find { |f| f.name == entity_array_item } or fail Errors::VSphereError, :missing_resource_pool
+                rp = rp.childEntity.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
               elsif rp.is_a? RbVmomi::VIM::ClusterComputeResource
-                rp = rp.resourcePool.resourcePool.find { |f| f.name == entity_array_item } or fail Errors::VSphereError, :missing_resource_pool
+                rp = rp.resourcePool.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
               elsif rp.is_a? RbVmomi::VIM::ResourcePool
-                rp = rp.resourcePool.find { |f| f.name == entity_array_item } or fail Errors::VSphereError, :missing_resource_pool
+                rp = rp.resourcePool.find { |f| f.name == entity_array_item } || (fail Errors::VSphereError, :missing_resource_pool)
               else
                 fail Errors::VSphereError, :missing_resource_pool
               end
             end
           end
-          rp = rp.resourcePool if not rp.is_a?(RbVmomi::VIM::ResourcePool) and rp.respond_to?(:resourcePool)
+          rp = rp.resourcePool if !rp.is_a?(RbVmomi::VIM::ResourcePool) && rp.respond_to?(:resourcePool)
           rp
         end
 

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
             elsif rp.is_a? RbVmomi::VIM::ResourcePool
               rp = rp.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
             else
-              fail(Errors::VSphereError, :missing_resource_pool)
+              fail Errors::VSphereError, :missing_resource_pool
             end
           end
           rp = rp.resourcePool if !rp.is_a?(RbVmomi::VIM::ResourcePool) && rp.respond_to?(:resourcePool)

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -23,9 +23,9 @@ module VagrantPlugins
             elsif rp.is_a? RbVmomi::VIM::ClusterComputeResource
               rp = rp.resourcePool.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
             elsif rp.is_a? RbVmomi::VIM::ResourcePool
-              rp = rp.resourcePool.find { |f| f.name == entity_array_item } || (fail Errors::VSphereError, :missing_resource_pool)
+              rp = rp.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
             else
-              fail Errors::VSphereError, :missing_resource_pool
+              fail(Errors::VSphereError, :missing_resource_pool)
             end
           end
           rp = rp.resourcePool if !rp.is_a?(RbVmomi::VIM::ResourcePool) && rp.respond_to?(:resourcePool)

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
             elsif rp.is_a? RbVmomi::VIM::ResourcePool
               rp = rp.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
             else
-              fail Errors::VSphereError, :missing_resource_pool
+              fail "Unexpected Object type encountered"
             end
           end
           rp = rp.resourcePool if !rp.is_a?(RbVmomi::VIM::ResourcePool) && rp.respond_to?(:resourcePool)

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
             elsif rp.is_a? RbVmomi::VIM::ResourcePool
               rp = rp.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
             else
-              fail "Unexpected Object type encountered"
+              fail 'Unexpected Object type encountered'
             end
           end
           rp = rp.resourcePool if !rp.is_a?(RbVmomi::VIM::ResourcePool) && rp.respond_to?(:resourcePool)

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -16,8 +16,7 @@ module VagrantPlugins
           rp = get_compute_resource(datacenter, machine)
           entity_array = machine.provider_config.resource_pool_name.split('/')
           entity_array.each do |entity_array_item|
-            puts entity_array_item
-            next if entity_array_item == ''
+            next if entity_array_item.empty?
             if rp.is_a? RbVmomi::VIM::Folder
               rp = rp.childEntity.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
             elsif rp.is_a? RbVmomi::VIM::ClusterComputeResource

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -16,16 +16,16 @@ module VagrantPlugins
           rp = get_compute_resource(datacenter, machine)
           entity_array = machine.provider_config.resource_pool_name.split('/')
           entity_array.each do |entity_array_item|
-            if entity_array_item != ''
-              if rp.is_a? RbVmomi::VIM::Folder
-                rp = rp.childEntity.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
-              elsif rp.is_a? RbVmomi::VIM::ClusterComputeResource
-                rp = rp.resourcePool.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
-              elsif rp.is_a? RbVmomi::VIM::ResourcePool
-                rp = rp.resourcePool.find { |f| f.name == entity_array_item } || (fail Errors::VSphereError, :missing_resource_pool)
-              else
-                fail Errors::VSphereError, :missing_resource_pool
-              end
+            puts entity_array_item
+            next if entity_array_item == ''
+            if rp.is_a? RbVmomi::VIM::Folder
+              rp = rp.childEntity.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
+            elsif rp.is_a? RbVmomi::VIM::ClusterComputeResource
+              rp = rp.resourcePool.resourcePool.find { |f| f.name == entity_array_item } || fail(Errors::VSphereError, :missing_resource_pool)
+            elsif rp.is_a? RbVmomi::VIM::ResourcePool
+              rp = rp.resourcePool.find { |f| f.name == entity_array_item } || (fail Errors::VSphereError, :missing_resource_pool)
+            else
+              fail Errors::VSphereError, :missing_resource_pool
             end
           end
           rp = rp.resourcePool if !rp.is_a?(RbVmomi::VIM::ResourcePool) && rp.respond_to?(:resourcePool)


### PR DESCRIPTION
Fixes #118 

You can specify resource pool like this:

```
vsphere.resource_pool_name = 'RPs/RP1/ChildRP'
```