### PR TITLE
Fix up gemspec versions to work as intended

### DIFF
--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -14,14 +14,14 @@ Gem::Specification.new do |s|
   # force the use of Nokogiri 1.5.x to prevent conflicts with older versions of zlib
   s.add_dependency 'nokogiri', '~>1.5'
   # force the use of rbvmomi 1.8.2 to work around concurrency errors: https://github.com/nsidc/vagrant-vsphere/issues/139
-  s.add_dependency 'rbvmomi', '~> 1.8.2'
-  s.add_dependency 'i18n', '~> 0.6.4'
+  s.add_dependency 'rbvmomi', '~> 1.8', '>= 1.8.2'
+  s.add_dependency 'i18n', '~> 0.6', '>= 0.6.4'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'rspec-expectations'
   s.add_development_dependency 'rspec-mocks'
-  s.add_development_dependency 'rubocop', '~> 0.32.1'
+  s.add_development_dependency 'rubocop', '~> 0.32', '>= 0.32.1'
 
   s.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.executables = s.files.grep(/^bin\//) { |f| File.basename(f) }


### PR DESCRIPTION
I found I couldn't install the plugin as I already had i18n (0.7.0) installed:

```
$  vagrant plugin install vagrant-vsphere
Installing the 'vagrant-vsphere' plugin. This can take a few minutes...
The plugin(s) can't be installed due to the version conflicts below.
This means that the plugins depend on a library version that conflicts
with other plugins or Vagrant itself, creating an impossible situation
where Vagrant wouldn't be able to load the plugins.

You can fix the issue by either removing a conflicting plugin or
by contacting a plugin author to see if they can address the conflict.

Vagrant could not find compatible versions for gem "i18n":
  In Gemfile:
    vagrant-vsphere (>= 0) ruby depends on
      i18n (~> 0.6.4) ruby

    i18n (0.7.0)
```

To test, I've built the gem using the version specs in the PR and published it here:

https://rubygems.org/gems/wh-vagrant-vsphere

That installs fine:

```
$  vagrant plugin install wh-vagrant-vsphere
Installing the 'wh-vagrant-vsphere' plugin. This can take a few minutes...
Installed the plugin 'wh-vagrant-vsphere (1.5.0)'!
```