### PR TITLE
Add support for setting guestinfo variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ This provider has the following settings, all are required unless noted:
   to the VM upon creation. This method takes a key/value pair,
   e.g. `vsphere.custom_attribute('timestamp', Time.now.to_s)`, and may be called
   multiple times to set different attributes.
+* `extra_config` - _Optional_ A hash of extra configuration values to add to
+  the VM during creation. These are of the form `{'guestinfo.some.variable' => 'somevalue'}`,
+  where the key must start with `guestinfo.`. VMs with VWware Tools installed can
+  retrieve the value of these variables using the `vmtoolsd` command: `vmtoolsd --cmd 'info-get guestinfo.some.variable'`.
 
 ### Cloning from a VM rather than a template
 

--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -41,6 +41,7 @@ module VagrantPlugins
             add_custom_cpu(spec, config.cpu_count) unless config.cpu_count.nil?
             add_custom_cpu_reservation(spec, config.cpu_reservation) unless config.cpu_reservation.nil?
             add_custom_mem_reservation(spec, config.mem_reservation) unless config.mem_reservation.nil?
+            add_custom_extra_config(spec, config.extra_config) unless config.extra_config.empty?
 
             if !config.clone_from_vm && ds.is_a?(RbVmomi::VIM::StoragePod)
 
@@ -232,6 +233,14 @@ module VagrantPlugins
 
         def add_custom_mem_reservation(spec, mem_reservation)
           spec[:config][:memoryAllocation] = RbVmomi::VIM.ResourceAllocationInfo(reservation: mem_reservation)
+        end
+
+        def add_custom_extra_config(spec, extra_config = {})
+          return if extra_config.empty?
+
+          # extraConfig must be an array of hashes with `key` and `value`
+          # entries.
+          spec[:config][:extraConfig] = extra_config.map { |k, v| { 'key' => k, 'value' => v } }
         end
       end
     end

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -26,11 +26,13 @@ module VagrantPlugins
       attr_accessor :cpu_count
       attr_accessor :cpu_reservation
       attr_accessor :mem_reservation
+      attr_accessor :extra_config
 
       attr_reader :custom_attributes
 
       def initialize
         @custom_attributes = {}
+        @extra_config = {}
       end
 
       def custom_attribute(key, value)

--- a/spec/clone_spec.rb
+++ b/spec/clone_spec.rb
@@ -99,4 +99,20 @@ describe VagrantPlugins::VSphere::Action::Clone do
               config: RbVmomi::VIM.VirtualMachineConfigSpec }
     )
   end
+
+  it 'should set extraConfig if specified' do
+    @machine.provider_config.stub(:extra_config).and_return(
+      'guestinfo.hostname' => 'somehost.testvm')
+    expected_config = RbVmomi::VIM.VirtualMachineConfigSpec(extraConfig: [
+      { 'key' => 'guestinfo.hostname', 'value' => 'somehost.testvm' }
+    ])
+
+    call
+    expect(@template).to have_received(:CloneVM_Task).with(
+      folder: @data_center,
+      name: NAME,
+      spec: { location: { pool: @child_resource_pool },
+              config: expected_config }
+    )
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,8 @@ RSpec.configure do |config|
         addressType: nil,
         cpu_reservation: nil,
         mem_reservation: nil,
-        custom_attributes: {})
+        custom_attributes: {},
+        extra_config: {})
     vm_config = double(
       vm: double('config_vm',
                  box: nil,


### PR DESCRIPTION
This patch adds an `extra_config` section to the provider configuration which
can be set to a hash. This hash is used to populate the `extraConfig` section
of the `VirtualMachineConfigSpec` used to clone new VMs. The keys of the hash
must start with `guestinfo.` and the values are available to guest VMs with
VMware tools installed via the `vmtoolsd` command.