### PR TITLE
Run provisioner cleanup when destroying VMs

### DIFF
--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
           b.use ConnectVSphere
+          b.use(ProvisionerCleanup, :before)
 
           b.use Call, IsRunning do |env, b2|
             if env[:result]


### PR DESCRIPTION
Vagrant v1.3.0 introduced the ability for provisioners to define cleanup tasks
that get run during VM destruction in order to clean up bits of global state.
This patch adds the ProvisionerCleanup task to the vSphere destroy action.