### PR TITLE
Allow status and ssh to run without a lock

### DIFF
--- a/lib/vSphere/provider.rb
+++ b/lib/vSphere/provider.rb
@@ -14,12 +14,12 @@ module VagrantPlugins
       end
 
       def ssh_info
-        env = @machine.action('get_ssh_info')
+        env = @machine.action('get_ssh_info', lock: false)
         env[:machine_ssh_info]
       end
 
       def state
-        env = @machine.action('get_state')
+        env = @machine.action('get_state', lock: false)
 
         state_id = env[:machine_state_id]
 


### PR DESCRIPTION
Prior to this patch long running operations, such as provisioners, would
prevent `vagrant status` or `vagrant ssh` from being run due to Vagrant
action locking. Attempting such actions would result in an error message. This
is inconvienant as shelling into a VM is a common debugging step in figuring
out why a provisioner is taking longer than usual.

Vagrant 1.7 introduced the ability to mark certain actions as not requireing a
lock. This patch adds `lock: false` to the `get_state` and `get_ssh_info` calls
which allows both `vagrant status` and `vagrant ssh` to function while a
long-running action is executing in another process. Vagrant 1.6 will ignore
the unknown `lock` option and fail as usual.