### PR TITLE
Allow vlans on virtual switches to work correctly

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -213,8 +213,7 @@ module VagrantPlugins
             begin
               switch_port = RbVmomi::VIM.DistributedVirtualSwitchPortConnection(switchUuid: network.config.distributedVirtualSwitch.uuid, portgroupKey: network.key)
               card.backing = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(port: switch_port)
-            rescue Exception => e
-              puts e
+            rescue
               # not connected to a distibuted switch?
               card.backing = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(network: network, deviceName: network.name)
             end

--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -212,8 +212,9 @@ module VagrantPlugins
           modify_network_card(template, spec) do |card|
             begin
               switch_port = RbVmomi::VIM.DistributedVirtualSwitchPortConnection(switchUuid: network.config.distributedVirtualSwitch.uuid, portgroupKey: network.key)
-              card.backing.port = switch_port
-            rescue
+              card.backing = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(port: switch_port)
+            rescue Exception => e
+              puts e
               # not connected to a distibuted switch?
               card.backing = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(network: network, deviceName: network.name)
             end


### PR DESCRIPTION
As #187 when joining a vlan on a virtual switch, line 215 was causing an exception. Setting to the correct class fixes the issue. To reproduce, try to join a vlan on a switch. Prior to this patch it would create a new vlan with the same name but not connected to the switch, which is no use.