### PR TITLE
Invalid ip address fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.1
+current_version = 1.8.2
 tag = true
 commit = true
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.2
+current_version = 1.9.0
 tag = true
 commit = true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.8.2 (2016-05-17)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.8.2)
+
+  - Add real_nic_ip option/logic to support VMs with multiple bridge adapters
+    ([vagrant-vsphere:invalid_ip_address_fix](https://github.com/nsidc/vagrant-vsphere/pull/193)).
+
 ## [1.8.1 (2016-04-27)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.8.1)
 
   - Fix error for initial VLAN/virtual switch support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.8.2 (2016-05-17)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.8.2)
+## [1.9.0 (2016-05-17)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.8.2)
 
   - Add real_nic_ip option/logic to support VMs with multiple bridge adapters
     ([vagrant-vsphere:invalid_ip_address_fix](https://github.com/nsidc/vagrant-vsphere/pull/193)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.9.0 (2016-05-17)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.8.2)
+## [1.9.0 (2016-05-17)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.9.0)
 
   - Add real_nic_ip option/logic to support VMs with multiple bridge adapters
     ([vagrant-vsphere:invalid_ip_address_fix](https://github.com/nsidc/vagrant-vsphere/pull/193)).

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This provider is built on top of the
 * libxml2, libxml2-dev, libxslt, libxslt-dev
 
 ## Current Version
-**version: 1.8.1**
+**version: 1.8.2**
 
-vagrant-vsphere (**version: 1.8.1**) is available from
+vagrant-vsphere (**version: 1.8.2**) is available from
 [RubyGems.org](https://rubygems.org/gems/vagrant-vsphere)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This provider is built on top of the
 * libxml2, libxml2-dev, libxslt, libxslt-dev
 
 ## Current Version
-**version: 1.8.2**
+**version: 1.9.0**
 
-vagrant-vsphere (**version: 1.8.2**) is available from
+vagrant-vsphere (**version: 1.9.0**) is available from
 [RubyGems.org](https://rubygems.org/gems/vagrant-vsphere)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ This provider has the following settings, all are required unless noted:
   where the key must start with `guestinfo.`. VMs with VWware Tools installed can
   retrieve the value of these variables using the `vmtoolsd` command: `vmtoolsd --cmd 'info-get guestinfo.some.variable'`.
 * `notes` - _Optional_ Add arbitrary notes to the VM
+* `real_nic_ip` - _Optional_ true/false - Enable ssh logic to validate the VM's IP address.  Vsphere pulls
+  all network cards on the host after provisioning may add new ones, in the case of container solutions (e.g.
+  Docker) it assigns a primary network card/IP to a virtual adapter, resulting in inability to ssh to the
+  machine via the plugin - enabling this option forces ssh to attempt to utilize the 'real' adapter
+  associated with the VM.   Multiple real adapters on the VM will result in a failure.
+
 
 ### Cloning from a VM rather than a template
 

--- a/README.md
+++ b/README.md
@@ -145,12 +145,10 @@ This provider has the following settings, all are required unless noted:
   where the key must start with `guestinfo.`. VMs with VWware Tools installed can
   retrieve the value of these variables using the `vmtoolsd` command: `vmtoolsd --cmd 'info-get guestinfo.some.variable'`.
 * `notes` - _Optional_ Add arbitrary notes to the VM
-* `real_nic_ip` - _Optional_ true/false - Enable ssh logic to validate the VM's IP address.  Vsphere pulls
-  all network cards on the host after provisioning may add new ones, in the case of container solutions (e.g.
-  Docker) it assigns a primary network card/IP to a virtual adapter, resulting in inability to ssh to the
-  machine via the plugin - enabling this option forces ssh to attempt to utilize the 'real' adapter
-  associated with the VM.   Multiple real adapters on the VM will result in a failure.
-
+* `real_nic_ip` - _Optional_ true/false - Enable logic that forces the acquisition of the ssh IP address
+  for a target VM to be retrieved from the list of vm adapters on the host and filtered for a single legitimate
+  adapter with a defined interface.   An error will be raised if this filter is enabled and multiple valid
+  adapters exist on a host. 
 
 ### Cloning from a VM rather than a template
 

--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -13,21 +13,28 @@ module VagrantPlugins
 
         def call(env)
           env[:machine_ssh_info] = get_ssh_info(env[:vSphere_connection], env[:machine])
-
           @app.call env
         end
 
         private
 
+        def filter_guest_nic(vm)
+          adapters = vm.guest.net.select { |g| g.deviceConfigId > 0 }.map { |g| g.ipAddress[0] }
+          fail Errors::VSphereError.new, 'real_nic_ip set to true with multiple valid VM network adapters' if adapters.size > 1
+          adapters.first
+        end
+
         def get_ssh_info(connection, machine)
           return nil if machine.id.nil?
 
           vm = get_vm_by_uuid connection, machine
-
           return nil if vm.nil?
-          return nil if vm.guest.ipAddress.nil? || vm.guest.ipAddress.empty?
+
+          ip_address = vm.guest.ipAddress
+          ip_address = filter_guest_nic(vm) if machine.provider_config.real_nic_ip
+          return nil if ip_address.nil? || ip_address.empty?
           {
-            host: vm.guest.ipAddress,
+            host: ip_address,
             port: 22
           }
         end

--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
 
         def filter_guest_nic(vm)
           adapters = vm.guest.net.select { |g| g.deviceConfigId > 0 }.map { |g| g.ipAddress[0] }
-          fail Errors::VSphereError.new, 'real_nic_ip set to true with multiple valid VM network adapters' if adapters.size > 1
+          fail Errors::VSphereError.new, 'real_nic_ip filtering set with multiple valid VM interfaces available' if adapters.size > 1
           adapters.first
         end
 

--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -18,7 +18,8 @@ module VagrantPlugins
 
         private
 
-        def filter_guest_nic(vm)
+        def filter_guest_nic(vm, machine)
+          return vm.guest.ipAddress unless machine.provider_config.real_nic_ip
           adapters = vm.guest.net.select { |g| g.deviceConfigId > 0 }.map { |g| g.ipAddress[0] }
           fail Errors::VSphereError.new, 'real_nic_ip filtering set with multiple valid VM interfaces available' if adapters.size > 1
           adapters.first
@@ -29,9 +30,7 @@ module VagrantPlugins
 
           vm = get_vm_by_uuid connection, machine
           return nil if vm.nil?
-
-          ip_address = vm.guest.ipAddress
-          ip_address = filter_guest_nic(vm) if machine.provider_config.real_nic_ip
+          ip_address = filter_guest_nic(vm, machine)
           return nil if ip_address.nil? || ip_address.empty?
           {
             host: ip_address,

--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -20,9 +20,9 @@ module VagrantPlugins
 
         def filter_guest_nic(vm, machine)
           return vm.guest.ipAddress unless machine.provider_config.real_nic_ip
-          adapters = vm.guest.net.select { |g| g.deviceConfigId > 0 }.map { |g| g.ipAddress[0] }
-          fail Errors::VSphereError.new, 'real_nic_ip filtering set with multiple valid VM interfaces available' if adapters.size > 1
-          adapters.first
+          ip_addresses = vm.guest.net.select { |g| g.deviceConfigId > 0 }.map { |g| g.ipAddress[0] }
+          fail Errors::VSphereError.new, :'multiple_interface_with_real_nic_ip_set' if ip_addresses.size > 1
+          ip_addresses.first
         end
 
         def get_ssh_info(connection, machine)

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -27,6 +27,7 @@ module VagrantPlugins
       attr_accessor :cpu_reservation
       attr_accessor :mem_reservation
       attr_accessor :extra_config
+      attr_accessor :real_nic_ip
       attr_accessor :notes
 
       attr_reader :custom_attributes

--- a/lib/vSphere/version.rb
+++ b/lib/vSphere/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VSphere
-    VERSION = '1.8.2'
+    VERSION = '1.9.0'
   end
 end

--- a/lib/vSphere/version.rb
+++ b/lib/vSphere/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VSphere
-    VERSION = '1.8.1'
+    VERSION = '1.8.2'
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -46,6 +46,8 @@ en:
         Cannot find network card to customize
       invalid_configuration_linked_clone_with_sdrs: |-
         Cannot use Linked Clone with Storage DRS
+      multiple_interface_with_real_nic_ip_set: |-
+        real_nic_ip filtering set with multiple valid VM interfaces available
 
     config:
       host: |-

--- a/spec/get_ssh_info_spec.rb
+++ b/spec/get_ssh_info_spec.rb
@@ -23,9 +23,64 @@ describe VagrantPlugins::VSphere::Action::GetSshInfo do
 
   it 'should set the ssh info host to the IP an existing VM' do
     @env[:machine].stub(:id).and_return(EXISTING_UUID)
-
     call
 
     expect(@env[:machine_ssh_info][:host]).to be IP_ADDRESS
+  end
+
+  context 'when acting on a VM with multiple network adapters' do
+    before do
+      allow(@vm.guest).to receive(:ipAddress) { '127.0.0.2' }
+      allow(@vm.guest).to receive(:net) {
+        [
+          double('guest_nic_info',
+                 ipAddress: ['127.0.0.2', 'mac address'],
+                 deviceConfigId: -1
+                ),
+          double('guest_nic_info',
+                 ipAddress: ['127.0.0.1', 'mac address'],
+                 deviceConfigId: 4000
+                )
+        ]
+      }
+      @env[:machine].stub(:id).and_return(EXISTING_UUID)
+    end
+    context 'when the real_nic_ip option is false' do
+      it 'sets the ssh info the original adapter' do
+        call
+        expect(@env[:machine_ssh_info][:host]).to eq '127.0.0.2'
+      end
+    end
+
+    context 'when the real_nic_ip option is true' do
+      before do
+        @env[:machine].provider_config.stub(:real_nic_ip).and_return(true)
+      end
+      context 'when there are mutiple valid adapters' do
+        before do
+          allow(@vm.guest).to receive(:net) {
+            [
+              double('guest_nic_info',
+                     ipAddress: ['127.0.0.2', 'mac address'],
+                     deviceConfigId: 4001
+                    ),
+              double('guest_nic_info',
+                     ipAddress: ['127.0.0.1', 'mac address'],
+                     deviceConfigId: 4000
+                    )
+            ]
+          }
+        end
+        it 'should raise an error' do
+          expect { call }.to raise_error(VagrantPlugins::VSphere::Errors::VSphereError)
+        end
+      end
+
+      it 'sets the ssh info host to the correct adapter' do
+        call
+        expect(@env[:machine_ssh_info][:host]).to eq IP_ADDRESS
+      end
+
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,7 +64,8 @@ RSpec.configure do |config|
         mem_reservation: nil,
         custom_attributes: {},
         notes: nil,
-        extra_config: {})
+        extra_config: {},
+        real_nic_ip: false)
     vm_config = double(
       vm: double('config_vm',
                  box: nil,


### PR DESCRIPTION
Fix in response to https://github.com/nsidc/vagrant-vsphere/issues/192

Adds an configurable option to allow the plugin to filter the machine network interfaces for one with an actual adapter and return that IP instead of  the vsphere primary ip address. 