### PR TITLE
Add snapshot support

### DIFF
--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -193,6 +193,21 @@ module VagrantPlugins
           b.use CloseVSphere
         end
       end
+
+      def self.action_snapshot_save
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectVSphere
+          b.use Call, IsCreated do |env, b2|
+            if env[:result]
+              b2.use SnapshotSave
+            else
+              b2.use MessageNotCreated
+            end
+          end
+          b.use CloseVSphere
+        end
+      end
       end # Vagrant > 1.8.0 guard
       # rubocop:enable IndentationWidth
 
@@ -216,6 +231,7 @@ module VagrantPlugins
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
       autoload :SnapshotList, action_root.join('snapshot_list')
+      autoload :SnapshotSave, action_root.join('snapshot_save')
       end
       # rubocop:enable IndentationWidth
     end

--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -176,6 +176,26 @@ module VagrantPlugins
         end
       end
 
+      # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
+      # rubocop:disable IndentationWidth
+      if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      def self.action_snapshot_list
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectVSphere
+          b.use Call, IsCreated do |env, b2|
+            if env[:result]
+              b2.use SnapshotList
+            else
+              b2.use MessageNotCreated
+            end
+          end
+          b.use CloseVSphere
+        end
+      end
+      end # Vagrant > 1.8.0 guard
+      # rubocop:enable IndentationWidth
+
       # autoload
       action_root = Pathname.new(File.expand_path('../action', __FILE__))
       autoload :Clone, action_root.join('clone')
@@ -191,6 +211,13 @@ module VagrantPlugins
       autoload :MessageNotRunning, action_root.join('message_not_running')
       autoload :PowerOff, action_root.join('power_off')
       autoload :PowerOn, action_root.join('power_on')
+
+      # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
+      # rubocop:disable IndentationWidth
+      if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      autoload :SnapshotList, action_root.join('snapshot_list')
+      end
+      # rubocop:enable IndentationWidth
     end
   end
 end

--- a/lib/vSphere/action.rb
+++ b/lib/vSphere/action.rb
@@ -179,6 +179,21 @@ module VagrantPlugins
       # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      def self.action_snapshot_delete
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectVSphere
+          b.use Call, IsCreated do |env, b2|
+            if env[:result]
+              b2.use SnapshotDelete
+            else
+              b2.use MessageNotCreated
+            end
+          end
+          b.use CloseVSphere
+        end
+      end
+
       def self.action_snapshot_list
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
@@ -230,6 +245,7 @@ module VagrantPlugins
       # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      autoload :SnapshotDelete, action_root.join('snapshot_delete')
       autoload :SnapshotList, action_root.join('snapshot_list')
       autoload :SnapshotSave, action_root.join('snapshot_save')
       end

--- a/lib/vSphere/action/snapshot_delete.rb
+++ b/lib/vSphere/action/snapshot_delete.rb
@@ -1,0 +1,38 @@
+require 'vSphere/util/vim_helpers'
+require 'vSphere/util/vm_helpers'
+
+module VagrantPlugins
+  module VSphere
+    module Action
+      class SnapshotDelete
+        include Util::VimHelpers
+        include Util::VmHelpers
+
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          vm = get_vm_by_uuid(env[:vSphere_connection], env[:machine])
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.deleting",
+            name: env[:snapshot_name]))
+
+          delete_snapshot(vm, env[:snapshot_name]) do |progress|
+            env[:ui].clear_line
+            env[:ui].report_progress(progress, 100, false)
+          end
+
+          env[:ui].clear_line
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.deleted",
+            name: env[:snapshot_name]))
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/lib/vSphere/action/snapshot_list.rb
+++ b/lib/vSphere/action/snapshot_list.rb
@@ -1,0 +1,25 @@
+require 'vSphere/util/vim_helpers'
+require 'vSphere/util/vm_helpers'
+
+module VagrantPlugins
+  module VSphere
+    module Action
+      class SnapshotList
+        include Util::VimHelpers
+        include Util::VmHelpers
+
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          vm = get_vm_by_uuid(env[:vSphere_connection], env[:machine])
+
+          env[:machine_snapshot_list] = enumerate_snapshots(vm).map(&:name)
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/lib/vSphere/action/snapshot_restore.rb
+++ b/lib/vSphere/action/snapshot_restore.rb
@@ -1,0 +1,34 @@
+require 'vSphere/util/vim_helpers'
+require 'vSphere/util/vm_helpers'
+
+module VagrantPlugins
+  module VSphere
+    module Action
+      class SnapshotRestore
+        include Util::VimHelpers
+        include Util::VmHelpers
+
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          vm = get_vm_by_uuid(env[:vSphere_connection], env[:machine])
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.restoring",
+            name: env[:snapshot_name]))
+
+          restore_snapshot(vm, env[:snapshot_name]) do |progress|
+            env[:ui].clear_line
+            env[:ui].report_progress(progress, 100, false)
+          end
+
+          env[:ui].clear_line
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/lib/vSphere/action/snapshot_save.rb
+++ b/lib/vSphere/action/snapshot_save.rb
@@ -1,0 +1,37 @@
+require 'vSphere/util/vim_helpers'
+require 'vSphere/util/vm_helpers'
+
+module VagrantPlugins
+  module VSphere
+    module Action
+      class SnapshotSave
+        include Util::VimHelpers
+        include Util::VmHelpers
+
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          vm = get_vm_by_uuid(env[:vSphere_connection], env[:machine])
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.saving",
+            name: env[:snapshot_name]))
+
+          create_snapshot(vm, env[:snapshot_name]) do |progress|
+            env[:ui].clear_line
+            env[:ui].report_progress(progress, 100, false)
+          end
+
+          env[:ui].clear_line
+
+          env[:ui].success(I18n.t(
+            "vagrant.actions.vm.snapshot.saved",
+            name: env[:snapshot_name]))
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/lib/vSphere/cap/snapshot_list.rb
+++ b/lib/vSphere/cap/snapshot_list.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module VSphere
+    module Cap
+      module SnapshotList
+        # Returns a list of the snapshots that are taken on this machine.
+        #
+        # @return [Array<String>] Snapshot Name
+        def self.snapshot_list(machine)
+          env = machine.action(:snapshot_list, lock: false)
+          env[:machine_snapshot_list]
+        end
+      end
+    end
+  end
+end

--- a/lib/vSphere/plugin.rb
+++ b/lib/vSphere/plugin.rb
@@ -35,6 +35,16 @@ module VagrantPlugins
         Cap::PublicAddress
       end
 
+      # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
+      # rubocop:disable IndentationWidth
+      if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      provider_capability('vsphere', 'snapshot_list') do
+        require_relative 'cap/snapshot_list'
+        Cap::SnapshotList
+      end
+      end
+      # rubocop:enable IndentationWidth
+
       def self.setup_i18n
         I18n.load_path << File.expand_path('locales/en.yml', VSphere.source_root)
         I18n.reload!

--- a/lib/vSphere/util/vm_helpers.rb
+++ b/lib/vSphere/util/vm_helpers.rb
@@ -69,6 +69,33 @@ module VagrantPlugins
 
           recursor.call(snapshot_root)
         end
+
+        # Create a named snapshot on a given VM
+        #
+        # This method creates a named snapshot on the given VM. This method
+        # blocks until the snapshot creation task is complete. An optional
+        # block can be passed which is used to report progress.
+        #
+        # @param vm [RbVmomi::VIM::VirtualMachine]
+        # @param name [String]
+        # @yield [Integer] Percentage complete as an integer. Called multiple
+        #   times.
+        #
+        # @return [void]
+        def create_snapshot(vm, name)
+          task = vm.CreateSnapshot_Task(
+            name: name,
+            memory: false,
+            quiesce: false)
+
+          if block_given?
+            task.wait_for_progress do |progress|
+              yield progress unless progress.nil?
+            end
+          else
+            task.wait_for_completion
+          end
+        end
       end
     end
   end

--- a/lib/vSphere/util/vm_helpers.rb
+++ b/lib/vSphere/util/vm_helpers.rb
@@ -96,6 +96,35 @@ module VagrantPlugins
             task.wait_for_completion
           end
         end
+
+        # Delete a named snapshot on a given VM
+        #
+        # This method deletes a named snapshot on the given VM. This method
+        # blocks until the snapshot deletion task is complete. An optional
+        # block can be passed which is used to report progress.
+        #
+        # @param vm [RbVmomi::VIM::VirtualMachine]
+        # @param name [String]
+        # @yield [Integer] Percentage complete as an integer. Called multiple
+        #   times.
+        #
+        # @return [void]
+        def delete_snapshot(vm, name)
+          snapshot = enumerate_snapshots(vm).find { |s| s.name == name }
+
+          # No snapshot matching "name"
+          return nil if snapshot.nil?
+
+          task = snapshot.snapshot.RemoveSnapshot_Task(removeChildren: false)
+
+          if block_given?
+            task.wait_for_progress do |progress|
+              yield progress unless progress.nil?
+            end
+          else
+            task.wait_for_completion
+          end
+        end
       end
     end
   end

--- a/lib/vSphere/util/vm_helpers.rb
+++ b/lib/vSphere/util/vm_helpers.rb
@@ -125,6 +125,35 @@ module VagrantPlugins
             task.wait_for_completion
           end
         end
+
+        # Restore a VM to a named snapshot
+        #
+        # This method restores a VM to the named snapshot state. This method
+        # blocks until the restoration task is complete. An optional block can
+        # be passed which is used to report progress.
+        #
+        # @param vm [RbVmomi::VIM::VirtualMachine]
+        # @param name [String]
+        # @yield [Integer] Percentage complete as an integer. Called multiple
+        #   times.
+        #
+        # @return [void]
+        def restore_snapshot(vm, name)
+          snapshot = enumerate_snapshots(vm).find { |s| s.name == name }
+
+          # No snapshot matching "name"
+          return nil if snapshot.nil?
+
+          task = snapshot.snapshot.RevertToSnapshot_Task(suppressPowerOn: true)
+
+          if block_given?
+            task.wait_for_progress do |progress|
+              yield progress unless progress.nil?
+            end
+          else
+            task.wait_for_completion
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This patchset adds provider actions required by the `vagrant snapshot` command introduced in Vagrant 1.8.0. The semantics of each action are modeled after the Virtualbox implementation:

https://github.com/mitchellh/vagrant/blob/v1.8.0/plugins/providers/virtualbox/action.rb#L230-L281

The actions make use of Vagrant UI strings introduced in 1.8.0 and are thus surrounded by guard statements to prevent them from being loaded by older Vagrant versions.