### PR TITLE
Wait for windows sysprep during clone

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -20,6 +20,8 @@ en:
       The VM has not been created
     vm_not_running: |-
       The VM is not running
+    wait_sysprep: |-
+      Waiting for sysprep
 
     errors:
       missing_template: |-
@@ -48,6 +50,8 @@ en:
         Cannot use Linked Clone with Storage DRS
       multiple_interface_with_real_nic_ip_set: |-
         real_nic_ip filtering set with multiple valid VM interfaces available
+      sysprep_timeout: |-
+        Customization of VM not succeeded within timeout.
 
     config:
       host: |-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,7 +75,8 @@ RSpec.configure do |config|
                  communicator: nil,
                  networks: [[:private_network, { ip: '0.0.0.0' }]],
                  boot_timeout: 1,
-                 graceful_halt_timeout: 0.1),
+                 graceful_halt_timeout: 0.1,
+                 guest: nil),
       validate: []
     )
     @app = double 'app', call: true


### PR DESCRIPTION
Machines reboot during the sysprep process. Vagrant needs to wait for this to
finish before attempting to access the machine.