### PR TITLE
SSPI support

### DIFF
--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -50,14 +50,13 @@ module VagrantPlugins
       def validate(machine)
         errors = _detected_errors
 
-        if password == :ask || password.nil?
+        if password == :ask
           self.password = machine.ui.ask('vSphere Password (will be hidden): ', echo: false)
         end
 
         # TODO: add blank?
         errors << I18n.t('vsphere.config.host') if host.nil?
-        errors <<  I18n.t('vsphere.config.user') if user.nil?
-        errors <<  I18n.t('vsphere.config.password') if password.nil?
+        errors <<  I18n.t('vsphere.config.user') if user.nil? && !password.nil?
         errors <<  I18n.t('vsphere.config.template') if template_name.nil?
 
         # Only required if we're cloning from an actual template

--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~>1.5'
   # force the use of at least rbvmomi 1.8.2 to work around concurrency errors:
   # https://github.com/nsidc/vagrant-vsphere/issues/139
-  s.add_dependency 'rbvmomi', '>=1.8.2', '<2.0.0'
+  s.add_dependency 'rbvmomi', '>=1.9.0', '<2.0.0'
   s.add_dependency 'i18n', '>= 0.6.4', '< 0.8.0'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Tested against rbvmomi 1.9.4; rbvmomi has had the SSPI support since 1.9.0 but I've been working on other projects and didn't know they'd released. Feel free to edit; there's probably a more elegant way to make these changes but the intent is not to require/pass a username/password if _neither_ is specified as this expresses the desire to try to use SSPI.