### PR TITLE
Utilize ipConfig.ipAddress to select the ‘preferred’ ip when ‘real_nic_ip’ filtering is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.11.1 (2017-02-27)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.11.1)
+  - Fix 'real_nic_ip' filter logic bug
+    ([vagrant-vsphere:fix_ssh_ip_selection](https://github.com/nsidc/vagrant-vsphere/pull/229))
+
 ## [1.11.0 (2016-11-23)](https://github.com/nsidc/vagrant-vsphere/releases/tag/v1.11.0)
 
   - Wait for Windows sysprep when cloning a Windows box

--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -20,9 +20,12 @@ module VagrantPlugins
 
         def filter_guest_nic(vm, machine)
           return vm.guest.ipAddress unless machine.provider_config.real_nic_ip
-          ip_addresses = vm.guest.net.select { |g| g.deviceConfigId > 0 }.map { |g| g.ipAddress[0] }
+
+          interfaces = vm.guest.net.select { |g| g.deviceConfigId > 0 }
+          ip_addresses = interfaces.map {|i| i.ipConfig.ipAddress.select {|a| a.state == 'preferred' }}.flatten
+
           fail Errors::VSphereError.new, :'multiple_interface_with_real_nic_ip_set' if ip_addresses.size > 1
-          ip_addresses.first
+          ip_addresses.first.ipAddress
         end
 
         def get_ssh_info(connection, machine)

--- a/lib/vSphere/action/get_ssh_info.rb
+++ b/lib/vSphere/action/get_ssh_info.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           return vm.guest.ipAddress unless machine.provider_config.real_nic_ip
 
           interfaces = vm.guest.net.select { |g| g.deviceConfigId > 0 }
-          ip_addresses = interfaces.map {|i| i.ipConfig.ipAddress.select {|a| a.state == 'preferred' }}.flatten
+          ip_addresses = interfaces.map { |i| i.ipConfig.ipAddress.select { |a| a.state == 'preferred' } }.flatten
 
           fail Errors::VSphereError.new, :'multiple_interface_with_real_nic_ip_set' if ip_addresses.size > 1
           ip_addresses.first.ipAddress

--- a/spec/get_ssh_info_spec.rb
+++ b/spec/get_ssh_info_spec.rb
@@ -63,7 +63,7 @@ describe VagrantPlugins::VSphere::Action::GetSshInfo do
                                              double('NetIpConfigInfoIpAddress',
                                                     ipAddress: '255.255.255.255', state: 'preferred')]
                                 )
-               ),
+               )
         ]
       }
     end
@@ -101,7 +101,7 @@ describe VagrantPlugins::VSphere::Action::GetSshInfo do
                                                  double('NetIpConfigInfoIpAddress',
                                                         ipAddress: '255.255.255.255', state: 'preferred')]
                                     )
-                   ),
+                   )
             ]
           }
 

--- a/spec/get_ssh_info_spec.rb
+++ b/spec/get_ssh_info_spec.rb
@@ -28,27 +28,50 @@ describe VagrantPlugins::VSphere::Action::GetSshInfo do
     expect(@env[:machine_ssh_info][:host]).to be IP_ADDRESS
   end
 
-  context 'when acting on a VM with multiple network adapters' do
+  context 'when acting on a VM with a single network adapter' do
     before do
       allow(@vm.guest).to receive(:ipAddress) { '127.0.0.2' }
-      allow(@vm.guest).to receive(:net) {
-        [
-          double('guest_nic_info',
-                 ipAddress: ['127.0.0.2', 'mac address'],
-                 deviceConfigId: -1
-                ),
-          double('guest_nic_info',
-                 ipAddress: ['127.0.0.1', 'mac address'],
-                 deviceConfigId: 4000
-                )
-        ]
-      }
       @env[:machine].stub(:id).and_return(EXISTING_UUID)
     end
+
+    it 'should return the correct ip address' do
+      call
+      expect(@env[:machine_ssh_info][:host]).to eq '127.0.0.2'
+    end
+  end
+
+  context 'when acting on a VM with multiple network adapters' do
+    before do
+      @env[:machine].stub(:id).and_return(EXISTING_UUID)
+      allow(@vm.guest).to receive(:net) {
+        [double('GuestNicInfo',
+                ipAddress: ['bad address', '127.0.0.1'],
+                deviceConfigId: 4000,
+                ipConfig: double('NetIpConfigInfo',
+                                 ipAddress: [double('NetIpConfigInfoIpAddress',
+                                                    ipAddress: 'bad address', state: 'unknown'),
+                                             double('NetIpConfigInfoIpAddress',
+                                                    ipAddress: '127.0.0.1', state: 'preferred')]
+                                )
+               ),
+         double('GuestNicInfo',
+                ipAddress: ['bad address', '255.255.255.255'],
+                deviceConfigId: -1,
+                ipConfig: double('NetIpConfigInfo',
+                                 ipAddress: [double('NetIpConfigInfoIpAddress',
+                                                    ipAddress: 'bad address', state: 'unknown'),
+                                             double('NetIpConfigInfoIpAddress',
+                                                    ipAddress: '255.255.255.255', state: 'preferred')]
+                                )
+               ),
+        ]
+      }
+    end
+
     context 'when the real_nic_ip option is false' do
       it 'sets the ssh info the original adapter' do
         call
-        expect(@env[:machine_ssh_info][:host]).to eq '127.0.0.2'
+        expect(@env[:machine_ssh_info][:host]).to eq IP_ADDRESS
       end
     end
 
@@ -59,17 +82,29 @@ describe VagrantPlugins::VSphere::Action::GetSshInfo do
       context 'when there are mutiple valid adapters' do
         before do
           allow(@vm.guest).to receive(:net) {
-            [
-              double('guest_nic_info',
-                     ipAddress: ['127.0.0.2', 'mac address'],
-                     deviceConfigId: 4001
-                    ),
-              double('guest_nic_info',
-                     ipAddress: ['127.0.0.1', 'mac address'],
-                     deviceConfigId: 4000
-                    )
+            [double('GuestNicInfo',
+                    ipAddress: ['bad address', '127.0.0.1'],
+                    deviceConfigId: 4000,
+                    ipConfig: double('NetIpConfigInfo',
+                                     ipAddress: [double('NetIpConfigInfoIpAddress',
+                                                        ipAddress: 'bad address', state: 'unknown'),
+                                                 double('NetIpConfigInfoIpAddress',
+                                                        ipAddress: '127.0.0.2', state: 'preferred')]
+                                    )
+                   ),
+             double('GuestNicInfo',
+                    ipAddress: ['bad address', '255.255.255.255'],
+                    deviceConfigId: 2000,
+                    ipConfig: double('NetIpConfigInfo',
+                                     ipAddress: [double('NetIpConfigInfoIpAddress',
+                                                        ipAddress: 'bad address', state: 'unknown'),
+                                                 double('NetIpConfigInfoIpAddress',
+                                                        ipAddress: '255.255.255.255', state: 'preferred')]
+                                    )
+                   ),
             ]
           }
+
         end
         it 'should raise an error' do
           expect { call }.to raise_error(VagrantPlugins::VSphere::Errors::VSphereError)

--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rbvmomi', '>=1.8.2', '<2.0.0'
   s.add_dependency 'i18n', '>= 0.6.4', '< 0.8.0'
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '11.1.2' # pinned to accommodate rubocop 0.32.1
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'rspec-expectations'
   s.add_development_dependency 'rspec-mocks'


### PR DESCRIPTION
Instead of relying on the first vm.guest.net.ipAddress, read the ipConfig object for a ‘preferred’ ipAddress.