### PR TITLE
Fix version constraint on i18n so it installs under Vagrant 1.9.2

### DIFF
--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # force the use of at least rbvmomi 1.8.2 to work around concurrency errors:
   # https://github.com/nsidc/vagrant-vsphere/issues/139
   s.add_dependency 'rbvmomi', '>=1.8.2', '<2.0.0'
-  s.add_dependency 'i18n', '>= 0.6.4', '< 0.8.0'
+  s.add_dependency 'i18n'
 
   s.add_development_dependency 'rake', '11.1.2' # pinned to accommodate rubocop 0.32.1
   s.add_development_dependency 'rspec-core'

--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # force the use of at least rbvmomi 1.8.2 to work around concurrency errors:
   # https://github.com/nsidc/vagrant-vsphere/issues/139
   s.add_dependency 'rbvmomi', '>=1.8.2', '<2.0.0'
-  s.add_dependency 'i18n'
+  s.add_dependency 'i18n', '>=0.6.4', '<=0.8.0'
 
   s.add_development_dependency 'rake', '11.1.2' # pinned to accommodate rubocop 0.32.1
   s.add_development_dependency 'rspec-core'


### PR DESCRIPTION
Vagrant specifies >=0.6.0, <0.8.0, but somehow giving the same spec in this
plugin prevents it from installing, as apparently 0.8.0 is wanted. Just removing
the version constraint seems to work.

Resolves #230 

@Jkovarik 