### PR TITLE
Make the waiting for windows sysprep functionality configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,11 @@ This provider has the following settings, all are required unless noted:
   for a target VM to be retrieved from the list of vm adapters on the host and filtered for a single legitimate
   adapter with a defined interface.   An error will be raised if this filter is enabled and multiple valid
   adapters exist on a host.
-* `ip_address_timeout` _ _Optional_ Maximum number of seconds to wait while an
+* `ip_address_timeout` - _Optional_ Maximum number of seconds to wait while an
   IP address is obtained
+* `wait_for_sysprep` - _Optional_ Boolean. Enable waiting for Windows machines to reboot
+  during the sysprep process
+  ([#199](https://github.com/nsidc/vagrant-vsphere/pull/199)). Defaults to `false`.
 
 ### Cloning from a VM rather than a template
 

--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -106,7 +106,7 @@ module VagrantPlugins
 
           machine.id = new_vm.config.uuid
 
-          wait_for_sysprep(env, new_vm, connection, 600, 10) if machine.config.vm.guest.eql?(:windows)
+          wait_for_sysprep(env, new_vm, connection, 600, 10) if config.wait_for_sysprep && machine.config.vm.guest.eql?(:windows)
 
           env[:ui].info I18n.t('vsphere.vm_clone_success')
 

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -36,6 +36,7 @@ module VagrantPlugins
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
+        @wait_for_sysprep = UNSET_VALUE
         @custom_attributes = {}
         @extra_config = {}
       end

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -30,6 +30,7 @@ module VagrantPlugins
       attr_accessor :extra_config
       attr_accessor :real_nic_ip
       attr_accessor :notes
+      attr_accessor :wait_for_sysprep
 
       attr_reader :custom_attributes
 
@@ -41,6 +42,7 @@ module VagrantPlugins
 
       def finalize!
         @ip_address_timeout = 240 if @ip_address_timeout == UNSET_VALUE
+        @wait_for_sysprep = false if @wait_for_sysprep == UNSET_VALUE
       end
 
       def custom_attribute(key, value)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,8 @@ RSpec.configure do |config|
         notes: nil,
         extra_config: {},
         ip_address_timeout: 1,
-        real_nic_ip: false)
+        real_nic_ip: false,
+        wait_for_sysprep: false)
     vm_config = double(
       vm: double('config_vm',
                  box: nil,


### PR DESCRIPTION
Fixes #222, which arose from #199 