### PR TITLE
Report VM clone progress

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -89,7 +89,14 @@ module VagrantPlugins
               env[:ui].info " -- #{config.clone_from_vm ? 'Source' : 'Template'} VM: #{template.pretty_path}"
               env[:ui].info " -- Target VM: #{vm_base_folder.pretty_path}/#{name}"
 
-              new_vm = template.CloneVM_Task(folder: vm_base_folder, name: name, spec: spec).wait_for_completion
+              last_progress = 0;
+              new_vm = template.CloneVM_Task(folder: vm_base_folder, name: name, spec: spec) .wait_for_progress do |progress|
+                  if (progress.is_a? Numeric) && (progress/10).floor != (last_progress/10).floor
+                      env[:ui].info "Progress: #{progress}%"
+                      last_progress = progress
+                  end
+              end
+              env[:ui].info "Done!"
 
               config.custom_attributes.each do |k, v|
                 env[:ui].info "Setting custom attribute: #{k}=#{v}"


### PR DESCRIPTION
In order to prevent:
https://github.com/vmware/rbvmomi/issues/118
https://github.com/nsidc/vagrant-vsphere/issues/106

Report progress during VM clone to avoid SOAP API proxy timeouts (and it's nice from the user perspective that it's just taking so long)

```
-----> Creating <centos-7>...
       Bringing machine 'default' up with 'vsphere' provider...
       ==> default: Calling vSphere CloneVM with the following settings:
       ==> default:  -- Template VM: xxxxxxx/vm/Templates/Linux/centos-7-server
       ==> default:  -- Target VM: xxxxxxxx/vm/TEST/test-rbvmomi-unstable-centos-7_default_1503437202177_3869
       ==> default: Progress: 11%
       ==> default: Progress: 22%
       ==> default: Progress: 39%
       ==> default: Progress: 40%
       ==> default: Progress: 50%
       ==> default: Progress: 60%
       ==> default: Progress: 70%
       ==> default: Progress: 80%
       ==> default: Progress: 90%
       ==> default: Done!
       ==> default: New virtual machine successfully cloned
       ==> default: Waiting for the machine to report its IP address...
           default: Timeout: 900 seconds
```