### PR TITLE
Update il8n dependency for Vagrant 2.2.x

### DIFF
--- a/vSphere.gemspec
+++ b/vSphere.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rbvmomi', '>=1.11.5', '<2.0.0'
 
-  s.add_dependency 'i18n', '>=0.6.4', '<=0.8.0'
+  s.add_dependency 'i18n', '>=0.6.4', '<=1.1.1'
 
   s.add_development_dependency 'rake', '11.1.2' # pinned to accommodate rubocop 0.32.1
   s.add_development_dependency 'rspec-core'


### PR DESCRIPTION
Prior to this commit, the il8n dependency in the gemspec was limited to
0.8.0. In Vagrant 2.2.1 the il8n dependency was updated to 1.1.1, which
made this plugin incompatible with new versions of vagrant. This commit
increases the il8n dependency to include 1.1.1.

https://github.com/hashicorp/vagrant/commit/d179e5e117a8a589109d316dec9eda73d88bcea4