### PR TITLE
allow setting target host for vm

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -205,6 +205,7 @@ module VagrantPlugins
             location[:datastore] = datastore unless datastore.nil?
           end
           location[:pool] = get_resource_pool(dc, machine) unless machine.provider_config.clone_from_vm
+          location[:host] = get_target_host(dc, machine) unless machine.provider_config.target_host.nil?
           location
         end
 

--- a/lib/vSphere/config.rb
+++ b/lib/vSphere/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :data_center_name
       attr_accessor :compute_resource_name
       attr_accessor :resource_pool_name
+      attr_accessor :target_host
       attr_accessor :clone_from_vm
       attr_accessor :template_name
       attr_accessor :name

--- a/lib/vSphere/util/vim_helpers.rb
+++ b/lib/vSphere/util/vim_helpers.rb
@@ -42,6 +42,12 @@ module VagrantPlugins
           cr
         end
 
+        def get_target_host(datacenter, machine)
+          cr = find_clustercompute_or_compute_resource(datacenter, machine.provider_config.compute_resource_name)
+          hs = cr.host.find { |host| host.name == machine.provider_config.target_host }
+          hs
+        end
+
         def find_clustercompute_or_compute_resource(datacenter, path)
           if path.is_a? String
             es = path.split('/').reject(&:empty?)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
         password: 'testpassword',
         data_center_name: nil,
         compute_resource_name: 'testcomputeresource',
+        target_host: nil,
         resource_pool_name: 'testresourcepool',
         vm_base_path: nil,
         template_name: TEMPLATE,
@@ -122,6 +123,7 @@ RSpec.configure do |config|
                           vmFolder: vm_folder,
                           pretty_path: "data_center/#{vm_folder}",
                           find_compute_resource: @compute_resource,
+                          find_target_host: @target_host,
                           hostFolder: @host_folder)
 
     @device = RbVmomi::VIM::VirtualEthernetCard.new


### PR DESCRIPTION
allows loadbalancing vms on the esx hosts

we are using it like

...
```
(1..30).each do |i|
  config.vm.define "client-#{i}" do |client|
    client.vm.provider "vsphere"
    client.vm.provider :vsphere do |vsphere|
      vsphere.name = "client-#{i}"
      if i.even?
        vsphere.target_host = 'esxhost1'
      else
        vsphere.target_host = 'esxhost2'
      end
    end
  end
end
```
...