### PR TITLE
Preserve backtraces when re-raising errors

### DIFF
--- a/lib/vSphere/action/clone.rb
+++ b/lib/vSphere/action/clone.rb
@@ -99,7 +99,7 @@ module VagrantPlugins
           rescue Errors::VSphereError
             raise
           rescue StandardError => e
-            raise Errors::VSphereError.new, e.message
+            raise Errors::VSphereError.new, e.message, e.backtrace
           end
 
           # TODO: handle interrupted status in the environment, should the vm be destroyed?

--- a/lib/vSphere/action/close_vsphere.rb
+++ b/lib/vSphere/action/close_vsphere.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
         rescue Errors::VSphereError
           raise
         rescue StandardError => e
-          raise Errors::VSphereError.new, e.message
+          raise Errors::VSphereError.new, e.message, e.backtrace
         end
       end
     end

--- a/lib/vSphere/action/connect_vsphere.rb
+++ b/lib/vSphere/action/connect_vsphere.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
           rescue Errors::VSphereError
             raise
           rescue StandardError => e
-            raise Errors::VSphereError.new, e.message
+            raise Errors::VSphereError.new, e.message, e.backtrace
           end
         end
       end

--- a/lib/vSphere/action/destroy.rb
+++ b/lib/vSphere/action/destroy.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
           rescue Errors::VSphereError
             raise
           rescue StandardError => e
-            raise Errors::VSphereError.new, e.message
+            raise Errors::VSphereError.new, e.message, e.backtrace
           end
         end
       end


### PR DESCRIPTION
This commit updates locations where StandardError instances are rescued
and re-raised as VSphereError to preserve the backtrace info of the
original errors along with the message. This change makes debugging
easier as the backtrace leads to the location where the error originated
instead of the rescue block where it was re-raised.